### PR TITLE
[Compatibility] Support PyTorch 1.11

### DIFF
--- a/apex/contrib/csrc/multihead_attn/dropout.h
+++ b/apex/contrib/csrc/multihead_attn/dropout.h
@@ -5,7 +5,7 @@
 #elif defined(OLD_GENERATOR_PT110)
 #include <ATen/CUDAGeneratorImpl.h>
 #else
-#include <ATen/CUDAGeneratorImpl.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
 #endif
 
 #include <ATen/cuda/CUDAContext.h>

--- a/apex/contrib/csrc/multihead_attn/dropout.h
+++ b/apex/contrib/csrc/multihead_attn/dropout.h
@@ -1,7 +1,9 @@
 #include <ATen/ATen.h>
 
-#ifdef OLD_GENERATOR
+#ifdef OLD_GENERATOR_PT109
 #include <ATen/CUDAGenerator.h>
+#elif defined(OLD_GENERATOR_PT110)
+#include <ATen/CUDAGeneratorImpl.h>
 #else
 #include <ATen/CUDAGeneratorImpl.h>
 #endif
@@ -210,7 +212,7 @@ void apex_fused_dropout_cuda(scalar_t const *inputs,
   std::pair<uint64_t, uint64_t> rng_engine_inputs;
   {
     // See Note [Acquire lock when using random generators]
-#ifdef OLD_GENERATOR
+#ifdef OLD_GENERATOR_PT109
     std::lock_guard<std::mutex> lock(gen->mutex_);
     rng_engine_inputs = gen->philox_engine_inputs(counter_offset);
 #else
@@ -248,7 +250,7 @@ void apex_dropout_add_cuda(scalar_t const *inputs,
   std::pair<uint64_t, uint64_t> rng_engine_inputs;
   {
     // See Note [Acquire lock when using random generators]
-#ifdef OLD_GENERATOR
+#ifdef OLD_GENERATOR_PT109
     std::lock_guard<std::mutex> lock(gen->mutex_);
     rng_engine_inputs = gen->philox_engine_inputs(counter_offset);
 #else

--- a/csrc/multi_tensor_lans.cu
+++ b/csrc/multi_tensor_lans.cu
@@ -1,11 +1,19 @@
 #include <ATen/ATen.h>
 #include <ATen/AccumulateType.h>
-#include <ATen/CUDAGeneratorImpl.h>
 #include <ATen/cuda/CUDAGraphsUtils.cuh>
 #include <ATen/cuda/CUDAContext.h>
 #include <ATen/cuda/Exceptions.h>
 // Another possibility:
 // #include <torch/all.h>
+
+#ifdef OLD_GENERATOR_PT109
+#include <ATen/CUDAGenerator.h>
+#elif defined(OLD_GENERATOR_PT110)
+#include <ATen/CUDAGeneratorImpl.h>
+#else
+#include <ATen/CUDAGeneratorImpl.h>
+#endif
+
 
 #include <curand_kernel.h>
 #include <assert.h>

--- a/csrc/multi_tensor_lans.cu
+++ b/csrc/multi_tensor_lans.cu
@@ -11,7 +11,7 @@
 #elif defined(OLD_GENERATOR_PT110)
 #include <ATen/CUDAGeneratorImpl.h>
 #else
-#include <ATen/CUDAGeneratorImpl.h>
+#include <ATen/cuda/CUDAGeneratorImpl.h>
 #endif
 
 

--- a/setup.py
+++ b/setup.py
@@ -295,11 +295,17 @@ if "--deprecated_fused_lamb" in sys.argv:
                                               'nvcc':['-O3',
                                                       '--use_fast_math'] + version_dependent_macros}))
 
-# Check, if ATen/CUDAGenerator.h is found, otherwise use the new ATen/CUDAGeneratorImpl.h, due to breaking change in https://github.com/pytorch/pytorch/pull/36026
+# Check, if ATen/CUDAGenerator.h is found, otherwise use the new ATen/CUDAGeneratorImpl.h, due to breaking change
+# See https://github.com/pytorch/pytorch/pull/36026
 generator_flag = []
 torch_dir = torch.__path__[0]
 if os.path.exists(os.path.join(torch_dir, 'include', 'ATen', 'CUDAGenerator.h')):
-    generator_flag = ['-DOLD_GENERATOR']
+    generator_flag = ['-DOLD_GENERATOR_PT109']
+
+# Check, if ATen/CUDAGeneratorImpl.h is found, otherwise use the new ATen/cuda/CUDAGeneratorImpl.h, due to breaking change.
+# See https://github.com/pytorch/pytorch/pull/70650
+if os.path.exists(os.path.join(torch_dir, 'include', 'ATen', 'CUDAGeneratorImpl.h')):
+    generator_flag = ['-DOLD_GENERATOR_PT110']
 
 if "--fast_layer_norm" in sys.argv:
     sys.argv.remove("--fast_layer_norm")


### PR DESCRIPTION
PyTorch PR https://github.com/pytorch/pytorch/pull/70650 that moves `ATen/CUDAGeneratorImpl.h` to `ATen/cuda/CUDAGeneratorImpl.h` has been merged and included in PyTorch 1.11 stable release. Although upstream apex has changed accordingly, this branch isn't rebased to against it. While I'm not sure when the lans branch will be rebased, this PR adds a quick fix to make the lans branch compatible to PyTorch 1.11.

cc @szhengac 